### PR TITLE
[FE] 글 작성, 글 목록, 글 상세 화면 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@toast-ui/editor": "^3.2.2",
         "axios": "^1.3.4",
         "bootstrap": "^5.2.3",
         "bootstrap-icons": "^1.10.4",
@@ -2098,6 +2099,21 @@
       "resolved": "https://registry.npmjs.org/@soda/get-current-script/-/get-current-script-1.0.2.tgz",
       "integrity": "sha512-T7VNNlYVM1SgQ+VsMYhnDkcGmWhQdL0bDyGm5TlQ3GBXnJscEClUUOKduWTmm2zCnvNLC1hc3JpuXjs/nFOc5w==",
       "dev": true
+    },
+    "node_modules/@toast-ui/editor": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@toast-ui/editor/-/editor-3.2.2.tgz",
+      "integrity": "sha512-ASX7LFjN2ZYQJrwmkUajPs7DRr9FsM1+RQ82CfTO0Y5ZXorBk1VZS4C2Dpxinx9kl55V4F8/A2h2QF4QMDtRbA==",
+      "dependencies": {
+        "dompurify": "^2.3.3",
+        "prosemirror-commands": "^1.1.9",
+        "prosemirror-history": "^1.1.3",
+        "prosemirror-inputrules": "^1.1.3",
+        "prosemirror-keymap": "^1.1.4",
+        "prosemirror-model": "^1.14.1",
+        "prosemirror-state": "^1.3.4",
+        "prosemirror-view": "^1.18.7"
+      }
     },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
@@ -5091,6 +5107,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.5.tgz",
+      "integrity": "sha512-jggCCd+8Iqp4Tsz0nIvpcb22InKEBrGz5dw3EQJMs8HPJDsKbFIO3STYtAvCfDx26Muevn1MHVI0XxjgFfmiSA=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -8309,6 +8330,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/orderedmap": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.0.tgz",
+      "integrity": "sha512-/pIFexOm6S70EPdznemIz3BQZoJ4VTFrhqzu0ACBqBgeLsLxq8e6Jim63ImIfwW/zAD1AlXpRMlOv3aghmo4dA=="
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -9186,6 +9212,80 @@
         "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
+    "node_modules/prosemirror-commands": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.5.1.tgz",
+      "integrity": "sha512-ga1ga/RkbzxfAvb6iEXYmrEpekn5NCwTb8w1dr/gmhSoaGcQ0VPuCzOn5qDEpC45ql2oDkKoKQbRxLJwKLpMTQ==",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.3.0.tgz",
+      "integrity": "sha512-qo/9Wn4B/Bq89/YD+eNWFbAytu6dmIM85EhID+fz9Jcl9+DfGEo8TTSrRhP15+fFEoaPqpHSxlvSzSEbmlxlUA==",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.2.0.tgz",
+      "integrity": "sha512-eAW/M/NTSSzpCOxfR8Abw6OagdG0MiDAiWHQMQveIsZtoKVYzm0AflSPq/ymqJd56/Su1YPbwy9lM13wgHOFmQ==",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.1.tgz",
+      "integrity": "sha512-kVK6WGC+83LZwuSJnuCb9PsADQnFZllt94qPP3Rx/vLcOUV65+IbBeH2nS5cFggPyEVJhGkGrgYFRrG250WhHQ==",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.19.0.tgz",
+      "integrity": "sha512-/CvFGJnwc41EJSfDkQLly1cAJJJmBpZwwUJtwZPTjY2RqZJfM8HVbCreOY/jti8wTRbVyjagcylyGoeJH/g/3w==",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.2.tgz",
+      "integrity": "sha512-puuzLD2mz/oTdfgd8msFbe0A42j5eNudKAAPDB0+QJRw8cO1ygjLmhLrg9RvDpf87Dkd6D4t93qdef00KKNacQ==",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.7.1.tgz",
+      "integrity": "sha512-VteoifAfpt46z0yEt6Fc73A5OID9t/y2QIeR5MgxEwTuitadEunD/V0c9jQW8ziT8pbFM54uTzRLJ/nLuQjMxg==",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.30.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.30.2.tgz",
+      "integrity": "sha512-nTNzZvalQf9kHeEyO407LiV6DoOs/pXsid88UqW9Vvybo4ozJW2PJhkfZUxCUF1hR/9vJLdhxX84wuw9P9HsXA==",
+      "dependencies": {
+        "prosemirror-model": "^1.16.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -9583,6 +9683,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.3.tgz",
+      "integrity": "sha512-85aZYCxweiD5J8yTEbw+E6A27zSnLPNDL0WfPdw3YYodq7WjnTKo0q4dtyQ2gz23iPT8Q9CUyJtAaUNcTxRf5Q=="
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -10983,6 +11088,11 @@
       "peerDependencies": {
         "vue": "^3.2.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
+      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg=="
     },
     "node_modules/watchpack": {
       "version": "2.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "@toast-ui/editor": "^3.2.2",
     "axios": "^1.3.4",
     "bootstrap": "^5.2.3",
     "bootstrap-icons": "^1.10.4",

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -10,17 +10,21 @@ export default {
 
 <style>
 @font-face {
-  font-family: "LINESeedKR-Bd";
-  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_11-01@1.0/LINESeedKR-Bd.woff2") format("woff2");
-  font-weight: 700;
+  font-family: "GangwonEdu_OTFBoldA";
+  src: url("https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2201-2@1.0/GangwonEdu_OTFBoldA.woff") format("woff");
+  font-weight: normal;
   font-style: normal;
 }
 
 * {
-  font-family: "LINESeedKR-Bd", serif;
+  font-family: "GangwonEdu_OTFBoldA", serif;
 }
 
 input {
+  box-shadow: none !important;
+}
+
+textarea {
   box-shadow: none !important;
 }
 </style>

--- a/frontend/src/api/post.js
+++ b/frontend/src/api/post.js
@@ -1,0 +1,36 @@
+import Axios from "axios";
+
+const BASE_URL = process.env.VUE_APP_BASE_URL;
+const ACCESS_TOKEN_KEY = process.env.VUE_APP_ACCESS_TOKEN_KEY;
+
+const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+
+const axios = Axios.create({
+  baseURL: BASE_URL,
+  withCredentials: true,
+});
+
+const POST = {
+  async listRequest(curPage) {
+    return await axios.get("/api/post/list", {
+      params: {
+        page: curPage,
+      },
+    });
+  },
+  async detailRequest(postNum) {
+    return await axios.get("/api/post/detail/" + postNum);
+  },
+  writeRequest(data) {
+    return axios.post("/api/post/write", data, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bearer " + accessToken,
+      },
+    });
+  },
+  updateRequest() {},
+  deleteRequest() {},
+};
+
+export { POST };

--- a/frontend/src/components/BaseNavigation.vue
+++ b/frontend/src/components/BaseNavigation.vue
@@ -3,7 +3,8 @@
     <header class="d-flex justify-content-between py-4 border-bottom">
       <router-link to="/" class="d-flex align-items-center text-decoration-none">
         <span class="fs-4 text-black">
-          <i class="bi bi-pencil-square">게시판</i>
+          <i class="bi bi-pencil-square"></i>
+          &nbsp;게시판
         </span>
       </router-link>
       <ul class="nav nav-pills" v-if="isLogin">
@@ -34,8 +35,8 @@ export default {
   methods: {
     ...mapActions(["clearToken"]),
     logout() {
-      console.log("logout");
       this.clearToken();
+      this.$router.push("/");
     },
   },
 };

--- a/frontend/src/constants/message.js
+++ b/frontend/src/constants/message.js
@@ -7,6 +7,9 @@ const CLIENT_MESSAGE = {
   GOOD_USERNAME: "사용 가능한 아이디입니다.",
   GOOD_PASSWORD: "사용 가능한 비밀번호입니다.",
   GOOD_CONFIRM: "비밀번호가 일치합니다.",
+  REQUIRE_LOGIN: "로그인이 필요합니다.",
+  INPUT_POST_TITLE: "제목을 입력해 주세요.",
+  INPUT_POST_CONTNET: "내용을 입력해 주세요.",
 };
 
 const SERVER_MESSAGE = {
@@ -15,7 +18,7 @@ const SERVER_MESSAGE = {
   ERRC003: "잘못된 입력 값입니다.",
   ERRA001: "아이디 또는 비밀번호를 잘못 입력했습니다.",
   ERRM001: "사용 중인 닉네임입니다.",
-  ERRM002: "사용 중인 이메일입니다.",
+  ERRM002: "사용 중인 아이디입니다.",
   ERRM003: "회원을 찾을 수 없습니다.",
 };
 

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -2,6 +2,9 @@ import { createRouter, createWebHistory } from "vue-router";
 import HomeView from "@/views/HomeView.vue";
 import LoginView from "@/views/member/LoginView.vue";
 import SignupView from "@/views/member/SignupView.vue";
+import WriteView from "@/views/post/WriteView.vue";
+import DetailView from "@/views/post/DetailView.vue";
+import { CLIENT_MESSAGE } from "@/constants/message";
 
 const ACCESS_TOKEN_KEY = process.env.VUE_APP_ACCESS_TOKEN_KEY;
 
@@ -11,6 +14,16 @@ function isLogin(to, from, next) {
     next({
       name: "home",
     });
+  } else {
+    next();
+  }
+}
+
+function requireLogin(to, from, next) {
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+  if (!accessToken) {
+    alert(CLIENT_MESSAGE.REQUIRE_LOGIN);
+    next("/login");
   } else {
     next();
   }
@@ -33,6 +46,17 @@ const routes = [
     name: "signup",
     component: SignupView,
     beforeEnter: isLogin,
+  },
+  {
+    path: "/post/write",
+    name: "write",
+    component: WriteView,
+    beforeEnter: requireLogin,
+  },
+  {
+    path: "/post/detail/:postNum",
+    name: "detail",
+    component: DetailView,
   },
 ];
 

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -1,13 +1,113 @@
 <template>
-  <base-navigation />
+  <BaseNavigation />
+  <div class="container">
+    <div class="list-form mt-5">
+      <div class="text-center mb-5">
+        <h1>자유 게시판</h1>
+      </div>
+      <div class="d-flex justify-content-end mb-3" v-if="isLogin">
+        <router-link to="/post/write" class="btn btn-primary">
+          <i class="bi bi-pencil"></i>
+          &nbsp;글 작성
+        </router-link>
+      </div>
+      <table class="table">
+        <thead class="table-primary">
+          <tr class="text-center">
+            <th class="num">번호</th>
+            <th class="title">제목</th>
+            <th class="writer">작성자</th>
+            <th class="craeted">작성일</th>
+          </tr>
+        </thead>
+        <tbody class="text-center table-group-divider">
+          <tr v-for="post in items" :key="post.postNum">
+            <td>{{ post.postNum }}</td>
+            <td class="text-start">
+              <router-link :to="`/post/detail/${post.postNum}`" class="text-decoration-none text-dark">
+                {{ post.title }}
+              </router-link>
+            </td>
+            <td>{{ post.writer }}</td>
+            <td>{{ post.createdAt }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <div>
+        <nav aria-label="Page navigation example">
+          <ul class="pagination justify-content-center">
+            <li class="page-item disabled">
+              <a class="page-link">&laquo;</a>
+            </li>
+            <li class="page-item">
+              <a class="page-link" href="#">1</a>
+            </li>
+            <li class="page-item">
+              <a class="page-link" href="#">&raquo;</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script>
 import BaseNavigation from "@/components/BaseNavigation.vue";
+import { POST } from "@/api/post";
+import { mapGetters } from "vuex";
+
 export default {
   name: "HomeView",
   components: {
     BaseNavigation,
   },
+  computed: {
+    ...mapGetters(["isLogin"]),
+  },
+  data() {
+    return {
+      first: "",
+      last: "",
+      curPage: "",
+      items: [],
+    };
+  },
+  mounted() {
+    POST.listRequest().then((res) => {
+      this.items = res.data.posts;
+    });
+  },
 };
 </script>
+
+<style scoped>
+.list-form {
+  max-width: 1200px;
+  margin: auto;
+}
+
+.list-form tr th {
+  padding: 1.5rem;
+}
+
+.list-form tr td {
+  padding: 1rem;
+}
+
+.list-form .num {
+  width: 100px;
+}
+
+.list-form .title {
+  width: 600px;
+}
+
+.list-form .writer {
+  width: 200px;
+}
+
+.list-form .created {
+  width: 100px;
+}
+</style>

--- a/frontend/src/views/post/DetailView.vue
+++ b/frontend/src/views/post/DetailView.vue
@@ -1,0 +1,93 @@
+<template>
+  <BaseNavigation />
+  <div class="container">
+    <div class="detail-form">
+      <div class="mt-5">
+        <div class="mt-2">
+          <div>
+            <span>{{ post.writer }}</span>
+          </div>
+          <div class="d-flex justify-content-between align-items-center">
+            <div>
+              <small class="text-muted">{{ post.createdAt }}</small>
+            </div>
+            <div v-if="isLogin">
+              <button class="btn btn-sm btn-secondary me-2">수정</button>
+              <button class="btn btn-sm btn-danger">삭제</button>
+            </div>
+          </div>
+          <div class="mb-5 mt-2">
+            <h3>{{ post.title }}</h3>
+          </div>
+        </div>
+        <div class="content">
+          <div id="viewer" class="pb-3"></div>
+        </div>
+        <hr />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Viewer from "@toast-ui/editor/dist/toastui-editor-viewer";
+import "@toast-ui/editor/dist/toastui-editor-viewer.css";
+import BaseNavigation from "@/components/BaseNavigation.vue";
+import { POST } from "@/api/post";
+import { mapGetters } from "vuex";
+
+export default {
+  name: "DetailView",
+  components: {
+    BaseNavigation,
+  },
+  data() {
+    return {
+      viewer: "",
+      post: {
+        title: "",
+        writer: "",
+        createdAt: "",
+      },
+    };
+  },
+  computed: {
+    ...mapGetters(["isLogin"]),
+  },
+  mounted() {
+    this.postDetail();
+    this.viewer = new Viewer({
+      el: document.querySelector("#viewer"),
+      height: "600px",
+      initialValue: "<h1>Hello world!!</h1>",
+    });
+  },
+  methods: {
+    postDetail() {
+      const postNum = this.$route.params.postNum;
+      POST.detailRequest(postNum).then((res) => {
+        const post = res.data;
+        this.post.title = post.title;
+        this.post.writer = post.writer;
+        this.post.createdAt = post.createdAt;
+        this.viewer.setMarkdown(post.content);
+      });
+    },
+  },
+};
+</script>
+
+<style>
+.detail-form {
+  max-width: 1000px;
+  margin: auto;
+}
+
+.toastui-editor-contents h1 {
+  margin: 0 0 0 0;
+}
+
+.toastui-editor-contents p {
+  font-size: 1rem;
+}
+</style>

--- a/frontend/src/views/post/WriteView.vue
+++ b/frontend/src/views/post/WriteView.vue
@@ -1,0 +1,90 @@
+<template>
+  <BaseNavigation />
+  <div class="container">
+    <div class="write-form">
+      <form role="form" class="mt-5">
+        <div class="form-floating mb-3">
+          <input v-model="post.title" type="text" class="form-control" placeholder="제목" />
+          <label>제목</label>
+        </div>
+        <div id="editor"></div>
+        <div class="mt-3 text-end">
+          <button type="button" @click="write" class="btn btn-lg btn-primary me-3">작성</button>
+          <router-link to="/" class="btn btn-lg btn-danger">취소</router-link>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script>
+import Editor from "@toast-ui/editor";
+import "@toast-ui/editor/dist/toastui-editor.css";
+import "@toast-ui/editor/dist/i18n/ko-kr";
+import BaseNavigation from "@/components/BaseNavigation.vue";
+import { CLIENT_MESSAGE } from "@/constants/message.js";
+import { POST } from "@/api/post";
+
+export default {
+  name: "WriteView",
+  components: {
+    BaseNavigation,
+  },
+  data() {
+    return {
+      editor: "",
+      post: {
+        title: "",
+        content: "",
+      },
+    };
+  },
+  mounted() {
+    this.editor = new Editor({
+      el: document.querySelector("#editor"),
+      height: "400px",
+      previewStyle: "vertical",
+      initialEditType: "wysiwyg",
+      hideModeSwitch: true,
+      autofocus: false,
+      language: "ko-KR",
+    });
+    this.editor.removeToolbarItem("image");
+    this.editor.removeToolbarItem("indent");
+    this.editor.removeToolbarItem("outdent");
+    this.editor.removeToolbarItem("task");
+  },
+  methods: {
+    write() {
+      const title = this.post.title;
+      const content = this.editor.getHTML();
+      if (title === "") {
+        alert(CLIENT_MESSAGE.INPUT_POST_TITLE);
+        return;
+      }
+      if (content === "<p><br></p>") {
+        alert(CLIENT_MESSAGE.INPUT_POST_CONTNET);
+        return;
+      }
+      const data = {
+        title: this.post.title,
+        content: content,
+      };
+      POST.writeRequest(data).then(() => {
+        this.$router.push("/");
+      });
+    },
+  },
+};
+</script>
+
+<style>
+.write-form {
+  max-width: 900px;
+  margin: auto;
+}
+
+.toastui-editor-contents hr {
+  border-top: 1px solid black !important;
+}
+</style>


### PR DESCRIPTION
## 작업 내용

글 작성, 글 목록, 글 상세 화면 구현

### 세부 구현기능

- 글 작성, 글 목록, 글 상세 페이지 추가
- 로그아웃 하면 메인 페이지로 이동하게 변경
- 사용자 로그인 시 접근하면 안되는 페이지를 검사하는 로직 추가 ex) 로그인한 사용자는 로그인 페이지 밎 회원가입 페이지에 접근할 수 없다.
- 폰트 변경 LINESeedKR-Bd → GangwonEdu_OTFBoldA

#### 관련 이슈

close #16 
