### PR TITLE
[BE] 토큰 저장 기능 구현

### DIFF
--- a/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import com.backend.global.security.handler.LoginFailureHandler;
 import com.backend.global.security.handler.LoginSuccessHandler;
 import com.backend.global.security.handler.UnAuthorizedHandler;
 import com.backend.global.security.util.JwtUtil;
+import com.backend.token.service.TokenService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -36,6 +37,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
+    private final TokenService tokenService;
     private final UserDetailsService userDetailsService;
     private final ObjectMapper objectMapper;
 
@@ -79,7 +81,7 @@ public class SecurityConfig {
 
     @Bean
     public AuthenticationSuccessHandler loginSuccessHandler() {
-        return new LoginSuccessHandler(jwtUtil, objectMapper);
+        return new LoginSuccessHandler(tokenService, jwtUtil, objectMapper);
     }
 
     @Bean

--- a/backend/src/main/java/com/backend/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/backend/global/security/filter/JwtAuthenticationFilter.java
@@ -5,7 +5,6 @@ import com.backend.global.security.util.JwtUtil;
 
 import io.jsonwebtoken.Claims;
 
-import io.jsonwebtoken.lang.Strings;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -13,6 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -52,7 +52,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private String extractToken(HttpServletRequest request) {
         String header = request.getHeader(AUTHORIZATION_HEADER);
-        if (Strings.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
             return header.substring(BEARER_PREFIX.length()).trim();
         }
         return null;

--- a/backend/src/main/java/com/backend/token/domain/Token.java
+++ b/backend/src/main/java/com/backend/token/domain/Token.java
@@ -1,0 +1,47 @@
+package com.backend.token.domain;
+
+import com.backend.global.domain.BaseEntity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "TOKEN")
+@NoArgsConstructor
+@Getter
+public class Token extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "token_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String refreshToken;
+
+    @Column(name = "member_id", nullable = false)
+    private Long memberId;
+
+    @Builder
+    public Token(String username, String refreshToken, Long memberId) {
+        this.username = username;
+        this.refreshToken = refreshToken;
+        this.memberId = memberId;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/backend/src/main/java/com/backend/token/repository/TokenRepository.java
+++ b/backend/src/main/java/com/backend/token/repository/TokenRepository.java
@@ -1,0 +1,13 @@
+package com.backend.token.repository;
+
+import com.backend.token.domain.Token;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+
+    Optional<Token> findByUsername(String username);
+
+}

--- a/backend/src/main/java/com/backend/token/service/TokenService.java
+++ b/backend/src/main/java/com/backend/token/service/TokenService.java
@@ -1,0 +1,29 @@
+package com.backend.token.service;
+
+import com.backend.token.domain.Token;
+import com.backend.token.repository.TokenRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final TokenRepository tokenRepository;
+
+    @Transactional
+    public void syncRefreshToken(Long memberId, String username, String refreshToken) {
+        tokenRepository.findByUsername(username).ifPresentOrElse(
+                token -> token.updateRefreshToken(refreshToken),
+                () -> tokenRepository.save(Token.builder()
+                        .username(username)
+                        .refreshToken(refreshToken)
+                        .memberId(memberId)
+                        .build())
+        );
+    }
+
+}

--- a/backend/src/test/java/com/backend/auth/token/repository/TokenRepositoryTest.java
+++ b/backend/src/test/java/com/backend/auth/token/repository/TokenRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.backend.auth.token.repository;
+
+import com.backend.global.config.JpaAuditConfig;
+import com.backend.token.domain.Token;
+import com.backend.token.repository.TokenRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(JpaAuditConfig.class)
+class TokenRepositoryTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final String USERNAME = "yoonms0617";
+    private static final String REFRESH_TOKEN = "refreshToken";
+
+    @Autowired
+    private TokenRepository tokenRepository;
+
+    @Test
+    @DisplayName("토큰을 저장한다.")
+    void token_save_test() {
+        Token token = new Token(USERNAME, REFRESH_TOKEN, MEMBER_ID);
+
+        Long id = tokenRepository.save(token).getId();
+
+        assertThat(id).isNotNull();
+    }
+
+    @Test
+    @DisplayName("회원 아이디로 토큰을 조회한다.")
+    void token_username_test() {
+        Token token = new Token(USERNAME, REFRESH_TOKEN, MEMBER_ID);
+        Token save = tokenRepository.save(token);
+
+        Optional<Token> find = tokenRepository.findByUsername(USERNAME);
+
+        assertThat(find).isPresent();
+        assertThat(find.get()).usingRecursiveComparison().isEqualTo(save);
+    }
+
+}

--- a/backend/src/test/java/com/backend/auth/token/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/backend/auth/token/service/TokenServiceTest.java
@@ -1,0 +1,45 @@
+package com.backend.auth.token.service;
+
+import com.backend.token.domain.Token;
+import com.backend.token.repository.TokenRepository;
+import com.backend.token.service.TokenService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.atLeastOnce;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceTest {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final String USERNAME = "yoonms0617";
+    private static final String REFRESH_TOKEN = "refreshToken";
+
+    @Mock
+    private TokenRepository tokenRepository;
+
+    @InjectMocks
+    private TokenService tokenService;
+
+    @Test
+    @DisplayName("새로운 토큰을 저장한다.")
+    void syncRefreshToken_test() {
+        Token token = new Token(USERNAME, REFRESH_TOKEN, MEMBER_ID);
+
+        given(tokenRepository.save(any(Token.class))).willReturn(token);
+
+        tokenService.syncRefreshToken(MEMBER_ID, USERNAME, REFRESH_TOKEN);
+
+        then(tokenRepository).should(atLeastOnce()).save(any(Token.class));
+    }
+
+}

--- a/backend/src/test/java/com/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/backend/member/controller/MemberControllerTest.java
@@ -10,6 +10,7 @@ import com.backend.member.exception.DuplicateNicknameException;
 import com.backend.member.exception.DuplicateUsernameException;
 import com.backend.member.service.MemberService;
 
+import com.backend.token.service.TokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.jsonwebtoken.Claims;
@@ -68,6 +69,9 @@ class MemberControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockBean
+    private TokenService tokenService;
 
     @MockBean
     private UserDetailsService userDetailsService;

--- a/backend/src/test/java/com/backend/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/backend/post/controller/PostControllerTest.java
@@ -10,6 +10,7 @@ import com.backend.post.dto.PostWriteRequest;
 import com.backend.post.exception.NotFoundPostException;
 import com.backend.post.service.PostService;
 
+import com.backend.token.service.TokenService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.jsonwebtoken.Claims;
@@ -66,6 +67,9 @@ class PostControllerTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @MockBean
+    private TokenService tokenService;
 
     @MockBean
     private UserDetailsService userDetailsService;


### PR DESCRIPTION
## 작업 내용

토큰 저장 기능 구현

### 세부 구현기능

- Token 엔티티 추가
- 로그인 성공시 Refresh token을 데이터베이스에 저장한다.
- 새롭게 로그인할 때마다 새로운 Refresh Token으로 업데이트 한다.

#### 관련 이슈

close #30 
