### PR TITLE
[BE] Access token 재발급 기능 구현

### DIFF
--- a/backend/src/main/java/com/backend/global/error/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/backend/global/error/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.backend.global.error.exception.BaseException;
 import com.backend.global.error.exception.ErrorType;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,8 +27,15 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<ErrorResponse> handle() {
+    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException() {
         ErrorResponse response = ErrorResponse.of(ErrorType.UNSUPPORTED_METHOD_TYPE);
+        return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handlerAuthenticationException(AuthenticationException e) {
+        ErrorType errorType = ErrorType.findByCode(e.getMessage());
+        ErrorResponse response = ErrorResponse.of(errorType);
         return ResponseEntity.status(response.getStatus()).body(response);
     }
 

--- a/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/backend/global/security/config/SecurityConfig.java
@@ -72,7 +72,7 @@ public class SecurityConfig {
                         .failureHandler(loginFailureHandler())
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .antMatchers("/api/member/signup", "/api/member/nickname/exists", "/api/member/username/exists", "/api/post/detail/**", "/api/post/list").permitAll()
+                        .antMatchers("/api/member/signup", "/api/member/nickname/exists", "/api/member/username/exists", "/api/post/detail/**", "/api/post/list", "/api/token/reissue").permitAll()
                         .antMatchers("/api/member/profile", "/api/post/write", "/api/post/update/**", "/api/post/delete/**").hasRole("MEMBER")
                         .anyRequest().authenticated()
                 );

--- a/backend/src/main/java/com/backend/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/backend/global/security/filter/JwtAuthenticationFilter.java
@@ -30,7 +30,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final String[] WHITE_LIST = {
             "/api/auth/login",
             "/api/member/signup", "/api/member/nickname/exists", "/api/member/username/exists",
-            "/api/post/detail", "/api/post/list"
+            "/api/post/detail", "/api/post/list",
+            "/api/token/reissue"
     };
 
     private final JwtUtil jwtUtil;

--- a/backend/src/main/java/com/backend/token/controller/TokenController.java
+++ b/backend/src/main/java/com/backend/token/controller/TokenController.java
@@ -1,0 +1,42 @@
+package com.backend.token.controller;
+
+import com.backend.token.dto.TokenResponse;
+import com.backend.token.service.TokenService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequestMapping("/api/token")
+@RequiredArgsConstructor
+public class TokenController {
+
+    private static final String EMPTY_STRING = "";
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer";
+
+    private final TokenService tokenService;
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenResponse> reIssueAccessToken(HttpServletRequest request) {
+        String refreshtoken = extractToken(request);
+        TokenResponse response = tokenService.reIssueAccessToken(refreshtoken);
+        return ResponseEntity.ok().body(response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String header = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(header) && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length()).trim();
+        }
+        return EMPTY_STRING;
+    }
+
+}

--- a/backend/src/main/java/com/backend/token/dto/TokenResponse.java
+++ b/backend/src/main/java/com/backend/token/dto/TokenResponse.java
@@ -1,0 +1,14 @@
+package com.backend.token.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TokenResponse {
+
+    private final String accessToken;
+
+    public TokenResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+}

--- a/backend/src/main/java/com/backend/token/service/TokenService.java
+++ b/backend/src/main/java/com/backend/token/service/TokenService.java
@@ -1,7 +1,13 @@
 package com.backend.token.service;
 
+import com.backend.global.error.exception.ErrorType;
+import com.backend.global.security.exception.InvalidTokenException;
+import com.backend.global.security.util.JwtUtil;
 import com.backend.token.domain.Token;
+import com.backend.token.dto.TokenResponse;
 import com.backend.token.repository.TokenRepository;
+
+import io.jsonwebtoken.Claims;
 
 import lombok.RequiredArgsConstructor;
 
@@ -13,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TokenService {
 
     private final TokenRepository tokenRepository;
+    private final JwtUtil jwtUtil;
 
     @Transactional
     public void syncRefreshToken(Long memberId, String username, String refreshToken) {
@@ -24,6 +31,32 @@ public class TokenService {
                         .memberId(memberId)
                         .build())
         );
+    }
+
+    @Transactional(readOnly = true)
+    public TokenResponse reIssueAccessToken(String refreshToken) {
+        jwtUtil.validatedToken(refreshToken);
+        Claims payload = jwtUtil.getPayload(refreshToken);
+        String username = String.valueOf(payload.get("username"));
+        Token token = tokenRepository.findByUsername(username)
+                .orElseThrow(() -> new InvalidTokenException(ErrorType.INVALID_TOKEN.getCode()));
+        boolean isSameRefreshToken = isSameRefreshToken(token.getRefreshToken(), refreshToken);
+        if (!isSameRefreshToken) {
+            throw new InvalidTokenException(ErrorType.INVALID_TOKEN.getCode());
+        }
+        String newAccessToken = createNewAccessToken(payload);
+        return new TokenResponse(newAccessToken);
+    }
+
+    private boolean isSameRefreshToken(String dbRefreshToken, String reqRefreshToken) {
+        return dbRefreshToken.equals(reqRefreshToken);
+    }
+
+    private String createNewAccessToken(Claims payload) {
+        Long memberId = Long.valueOf(payload.getSubject());
+        String username = String.valueOf(payload.get("username"));
+        String role = String.valueOf(payload.get("role"));
+        return jwtUtil.createAccessToken(memberId, username, role);
     }
 
 }

--- a/backend/src/test/java/com/backend/auth/token/controller/TokenControllerTest.java
+++ b/backend/src/test/java/com/backend/auth/token/controller/TokenControllerTest.java
@@ -1,0 +1,111 @@
+package com.backend.auth.token.controller;
+
+import com.backend.global.error.exception.ErrorType;
+import com.backend.global.security.config.SecurityConfig;
+import com.backend.global.security.exception.InvalidTokenException;
+import com.backend.global.security.util.JwtUtil;
+import com.backend.token.controller.TokenController;
+import com.backend.token.dto.TokenResponse;
+import com.backend.token.service.TokenService;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Date;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = TokenController.class)
+@Import(SecurityConfig.class)
+public class TokenControllerTest {
+
+    private static final Long ID = 1L;
+    private static final String USERNAME = "yoonms0617";
+    private static final String ROLE = "ROLE_MEMBER";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserDetailsService userDetailsService;
+
+    @MockBean
+    private JwtUtil jwtUtil;
+
+    @MockBean
+    private TokenService tokenService;
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+
+    @Test
+    @DisplayName("토큰을 재발급 받는다.")
+    void token_reissue_request_test() throws Exception {
+        TokenResponse response = new TokenResponse("newAccesstoken");
+        Date iat = new Date();
+        String refreshToken = Jwts.builder()
+                .setSubject(String.valueOf(ID))
+                .claim("username", USERNAME)
+                .claim("role", ROLE)
+                .setIssuedAt(iat)
+                .setExpiration(new Date(iat.getTime() + 3600000))
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+
+        given(tokenService.reIssueAccessToken(anyString())).willReturn(response);
+
+        ResultActions resultActions = mockMvc.perform(post("/api/token/reissue")
+                .header("Authorization", "Bearer " + refreshToken)
+        );
+
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("newAccesstoken"));
+    }
+
+    @Test
+    @DisplayName("유효하지 않는 토큰일 경우 재발급에 실패한다.")
+    void token_reissue_invalid_token_request_test() throws Exception {
+        ErrorType errorType = ErrorType.INVALID_TOKEN;
+
+        given(tokenService.reIssueAccessToken(anyString())).willThrow(new InvalidTokenException(ErrorType.INVALID_TOKEN.getCode()));
+
+        ResultActions resultActions = mockMvc.perform(post("/api/token/reissue")
+                .header("Authorization", "Bearer ")
+        );
+
+        resultActions
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(errorType.getCode()))
+                .andExpect(jsonPath("$.status").value(errorType.getStatus()))
+                .andExpect(jsonPath("$.message").value(errorType.getMessage()));
+    }
+
+}

--- a/backend/src/test/java/com/backend/auth/token/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/backend/auth/token/service/TokenServiceTest.java
@@ -1,5 +1,6 @@
 package com.backend.auth.token.service;
 
+import com.backend.global.security.util.JwtUtil;
 import com.backend.token.domain.Token;
 import com.backend.token.repository.TokenRepository;
 import com.backend.token.service.TokenService;
@@ -26,6 +27,9 @@ class TokenServiceTest {
 
     @Mock
     private TokenRepository tokenRepository;
+
+    @Mock
+    private JwtUtil jwtUtil;
 
     @InjectMocks
     private TokenService tokenService;


### PR DESCRIPTION
## 작업 내용

Access Token 만료시 새로운 Access Token 재발급 기능 추가

### 세부 구현기능

- Access Token 만료시 Refresh Token을 통해 새로운 Access Token을 재발급한 후 응답한다.
- 클라이언트에서 보낸 Refresh Token이 유효한지 검증한다.
- 클라이언트에서 보낸 Refresh Token과 데이터베이스에 저장된 Refresh Token을 비교해 같은지 검증한다.

#### 관련 이슈

close #29 
