### PR TITLE
[BE] 로그인 성공시 닉네임도 같이 반환하도록 변경

### DIFF
--- a/backend/src/main/java/com/backend/global/security/dto/LoginMember.java
+++ b/backend/src/main/java/com/backend/global/security/dto/LoginMember.java
@@ -10,13 +10,16 @@ public class LoginMember extends User {
 
     private final Long id;
 
+    private final String nickname;
+
     private final String username;
 
     private final String role;
 
-    public LoginMember(Long id, String username, String password, String role) {
+    public LoginMember(Long id, String nickname, String username, String password, String role) {
         super(username, password, AuthorityUtils.createAuthorityList(role));
         this.id = id;
+        this.nickname = nickname;
         this.username = username;
         this.role = role;
     }

--- a/backend/src/main/java/com/backend/global/security/dto/LoginResponse.java
+++ b/backend/src/main/java/com/backend/global/security/dto/LoginResponse.java
@@ -1,17 +1,31 @@
 package com.backend.global.security.dto;
 
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class LoginResponse {
 
-    private String accessToken;
+    private final String nickname;
 
-    private String refreshToken;
+    private final Token token;
+
+    public LoginResponse(String nickname, String accessToken, String refreshToken) {
+        this.nickname = nickname;
+        this.token = new Token(accessToken, refreshToken);
+    }
+
+    @Getter
+    private static class Token {
+
+        private final String accessToken;
+
+        private final String refreshToken;
+
+        public Token(String accessToken, String refreshToken) {
+            this.accessToken = accessToken;
+            this.refreshToken = refreshToken;
+        }
+
+    }
 
 }

--- a/backend/src/main/java/com/backend/global/security/filter/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/backend/global/security/filter/JwtAuthenticationFilter.java
@@ -61,9 +61,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private Authentication createAuth(Claims payload) {
         Long id = Long.valueOf(payload.getSubject());
+        String nickname = String.valueOf(payload.get("nickname"));
         String username = String.valueOf(payload.get("username"));
         String role = String.valueOf(payload.get("role"));
-        LoginMember loginMember = new LoginMember(id, username, "", role);
+        LoginMember loginMember = new LoginMember(id, nickname, username, "", role);
         return UsernamePasswordAuthenticationToken.authenticated(loginMember, null, loginMember.getAuthorities());
     }
 

--- a/backend/src/main/java/com/backend/global/security/handler/LoginSuccessHandler.java
+++ b/backend/src/main/java/com/backend/global/security/handler/LoginSuccessHandler.java
@@ -28,15 +28,19 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
         LoginMember loginMember = (LoginMember) authentication.getPrincipal();
-        LoginResponse loginResponse = loginResponse(loginMember);
-        syncRefreshToken(loginMember, loginResponse.getRefreshToken());
+        String accessToken = createAccessToken(loginMember);
+        String refreshToken = createRefreshToken(loginMember);
+        LoginResponse loginResponse = new LoginResponse(loginMember.getNickname(), accessToken, refreshToken);
+        syncRefreshToken(loginMember, refreshToken);
         objectMapper.writeValue(response.getOutputStream(), loginResponse);
     }
 
-    private LoginResponse loginResponse(LoginMember loginMember) {
-        String accessToken = jwtUtil.createAccessToken(loginMember.getId(), loginMember.getUsername(), loginMember.getRole());
-        String refreshToken = jwtUtil.createRefreshToken(loginMember.getId(), loginMember.getUsername(), loginMember.getRole());
-        return new LoginResponse(accessToken, refreshToken);
+    private String createAccessToken(LoginMember loginMember) {
+        return jwtUtil.createAccessToken(loginMember.getId(), loginMember.getNickname(), loginMember.getUsername(), loginMember.getRole());
+    }
+
+    private String createRefreshToken(LoginMember loginMember) {
+        return jwtUtil.createRefreshToken(loginMember.getId(), loginMember.getNickname(), loginMember.getUsername(), loginMember.getRole());
     }
 
     private void syncRefreshToken(LoginMember loginMember, String refreshToken) {

--- a/backend/src/main/java/com/backend/global/security/service/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/backend/global/security/service/UserDetailsServiceImpl.java
@@ -21,7 +21,13 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
-        return new LoginMember(member.getId(), member.getUsername(), member.getPassword(), member.getRole().getValue());
+        return new LoginMember(
+                member.getId(),
+                member.getNickname(),
+                member.getUsername(),
+                member.getPassword(),
+                member.getRole().getValue()
+        );
     }
 
 }

--- a/backend/src/main/java/com/backend/global/security/util/JwtUtil.java
+++ b/backend/src/main/java/com/backend/global/security/util/JwtUtil.java
@@ -37,19 +37,20 @@ public class JwtUtil {
         this.refreshTokenInMilliseconds = refreshTokenInMilliseconds;
     }
 
-    public String createAccessToken(Long id, String username, String role) {
-        return createToken(id, username, role, accessTokenInMilliseconds);
+    public String createAccessToken(Long id, String nickname, String username, String role) {
+        return createToken(id, nickname, username, role, accessTokenInMilliseconds);
     }
 
-    public String createRefreshToken(Long id, String username, String role) {
-        return createToken(id, username, role, refreshTokenInMilliseconds);
+    public String createRefreshToken(Long id, String nickname, String username, String role) {
+        return createToken(id, nickname, username, role, refreshTokenInMilliseconds);
     }
 
-    private String createToken(Long id, String username, String role, long tokenInMilliseconds) {
+    private String createToken(Long id, String nickname, String username, String role, long tokenInMilliseconds) {
         Date iat = new Date();
         Date exp = new Date(iat.getTime() + tokenInMilliseconds);
         return Jwts.builder()
                 .setSubject(String.valueOf(id))
+                .claim("nickname", nickname)
                 .claim("username", username)
                 .claim("role", role)
                 .setIssuedAt(iat)

--- a/backend/src/main/java/com/backend/token/service/TokenService.java
+++ b/backend/src/main/java/com/backend/token/service/TokenService.java
@@ -54,9 +54,10 @@ public class TokenService {
 
     private String createNewAccessToken(Claims payload) {
         Long memberId = Long.valueOf(payload.getSubject());
+        String nickname = String.valueOf(payload.get("nickname"));
         String username = String.valueOf(payload.get("username"));
         String role = String.valueOf(payload.get("role"));
-        return jwtUtil.createAccessToken(memberId, username, role);
+        return jwtUtil.createAccessToken(memberId, nickname, username, role);
     }
 
 }

--- a/backend/src/test/java/com/backend/auth/jwt/JwtUtilTest.java
+++ b/backend/src/test/java/com/backend/auth/jwt/JwtUtilTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class JwtUtilTest {
 
     private static final Long ID = 1L;
+    private static final String NICKNAME = "민수쿤";
     private static final String USERNAME = "yoonms0617";
     private static final String ROLE = "ROLE_MEMBER";
 
@@ -39,7 +40,7 @@ public class JwtUtilTest {
     @Test
     @DisplayName("Access Token을 생성한다.")
     void create_access_token_test() {
-        String accessToken = jwtUtil.createAccessToken(ID, USERNAME, ROLE);
+        String accessToken = jwtUtil.createAccessToken(ID, NICKNAME, USERNAME, ROLE);
 
         assertThat(accessToken).isNotNull();
     }
@@ -47,7 +48,7 @@ public class JwtUtilTest {
     @Test
     @DisplayName("Refresh Token을 생성한다.")
     void create_refresh_token_test() {
-        String refreshToken = jwtUtil.createRefreshToken(ID, USERNAME, ROLE);
+        String refreshToken = jwtUtil.createRefreshToken(ID, NICKNAME, USERNAME, ROLE);
 
         assertThat(refreshToken).isNotNull();
     }
@@ -55,7 +56,7 @@ public class JwtUtilTest {
     @Test
     @DisplayName("올바른 Access Token 정보로 Payload를 조회한다.")
     void payload_from_accessToken() {
-        String accessToken = jwtUtil.createAccessToken(ID, USERNAME, ROLE);
+        String accessToken = jwtUtil.createAccessToken(ID, NICKNAME, USERNAME, ROLE);
 
         Claims payload = jwtUtil.getPayload(accessToken);
 
@@ -68,7 +69,7 @@ public class JwtUtilTest {
     @Test
     @DisplayName("올바른 Refresh Token 정보로 Payload를 조회한다.")
     void payload_from_refreshToken() {
-        String refreshToken = jwtUtil.createRefreshToken(ID, USERNAME, ROLE);
+        String refreshToken = jwtUtil.createRefreshToken(ID, NICKNAME, USERNAME, ROLE);
 
         Claims payload = jwtUtil.getPayload(refreshToken);
 
@@ -81,7 +82,7 @@ public class JwtUtilTest {
     @Test
     @DisplayName("토큰이 유효하지 않는 경우 예외가 발생한다.")
     void invalid_token_test() {
-        String invalidToken = null;
+        String invalidToken = "";
 
         assertThatThrownBy(() -> jwtUtil.validatedToken(invalidToken))
                 .isInstanceOf(InvalidTokenException.class);


### PR DESCRIPTION
## 작업 내용

로그인 성공시 닉네임도 같이 반환하도록 변경

### 세부 구현기능

- 토큰 claim에 닉네임 정보 추가
- 로그인 성공시 토큰과 함께 로그인한 사용자의 닉네임도 함께 반환하도록 변경

#### 관련 이슈

close #35 
