### PR TITLE
[BE] 테스트시 반복적으로 사용되는 객체 분리

### DIFF
--- a/backend/src/main/java/com/backend/global/security/handler/UnAuthorizedHandler.java
+++ b/backend/src/main/java/com/backend/global/security/handler/UnAuthorizedHandler.java
@@ -27,6 +27,7 @@ public class UnAuthorizedHandler implements AuthenticationEntryPoint {
         ErrorType errorType = ErrorType.findByCode(code);
         ErrorResponse errorResponse = ErrorResponse.of(errorType);
         response.setCharacterEncoding("utf-8");
+        response.setStatus(errorResponse.getStatus());
         objectMapper.writeValue(response.getOutputStream(), errorResponse);
     }
 

--- a/backend/src/test/java/com/backend/auth/token/repository/TokenRepositoryTest.java
+++ b/backend/src/test/java/com/backend/auth/token/repository/TokenRepositoryTest.java
@@ -13,15 +13,15 @@ import org.springframework.context.annotation.Import;
 
 import java.util.Optional;
 
+import static com.backend.support.fixture.MemberFixture.MEMBER_ID;
+import static com.backend.support.fixture.MemberFixture.USERNAME;
+import static com.backend.support.fixture.JwtFixture.REFRESH_TOKEN;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @Import(JpaAuditConfig.class)
 class TokenRepositoryTest {
-
-    private static final Long MEMBER_ID = 1L;
-    private static final String USERNAME = "yoonms0617";
-    private static final String REFRESH_TOKEN = "refreshToken";
 
     @Autowired
     private TokenRepository tokenRepository;
@@ -40,12 +40,12 @@ class TokenRepositoryTest {
     @DisplayName("회원 아이디로 토큰을 조회한다.")
     void token_username_test() {
         Token token = new Token(USERNAME, REFRESH_TOKEN, MEMBER_ID);
-        Token save = tokenRepository.save(token);
+        Token expected = tokenRepository.save(token);
 
-        Optional<Token> find = tokenRepository.findByUsername(USERNAME);
+        Optional<Token> actual = tokenRepository.findByUsername(USERNAME);
 
-        assertThat(find).isPresent();
-        assertThat(find.get()).usingRecursiveComparison().isEqualTo(save);
+        assertThat(actual).isPresent();
+        assertThat(actual.get()).usingRecursiveComparison().isEqualTo(expected);
     }
 
 }

--- a/backend/src/test/java/com/backend/auth/token/service/TokenServiceTest.java
+++ b/backend/src/test/java/com/backend/auth/token/service/TokenServiceTest.java
@@ -13,6 +13,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static com.backend.support.fixture.AuthFixture.TOKEN;
+import static com.backend.support.fixture.JwtFixture.REFRESH_TOKEN;
+import static com.backend.support.fixture.MemberFixture.MEMBER_ID;
+import static com.backend.support.fixture.MemberFixture.USERNAME;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -20,10 +25,6 @@ import static org.mockito.Mockito.atLeastOnce;
 
 @ExtendWith(MockitoExtension.class)
 class TokenServiceTest {
-
-    private static final Long MEMBER_ID = 1L;
-    private static final String USERNAME = "yoonms0617";
-    private static final String REFRESH_TOKEN = "refreshToken";
 
     @Mock
     private TokenRepository tokenRepository;
@@ -37,9 +38,7 @@ class TokenServiceTest {
     @Test
     @DisplayName("새로운 토큰을 저장한다.")
     void syncRefreshToken_test() {
-        Token token = new Token(USERNAME, REFRESH_TOKEN, MEMBER_ID);
-
-        given(tokenRepository.save(any(Token.class))).willReturn(token);
+        given(tokenRepository.save(any(Token.class))).willReturn(TOKEN);
 
         tokenService.syncRefreshToken(MEMBER_ID, USERNAME, REFRESH_TOKEN);
 

--- a/backend/src/test/java/com/backend/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/backend/member/controller/MemberControllerTest.java
@@ -2,9 +2,8 @@ package com.backend.member.controller;
 
 import com.backend.global.error.exception.ErrorType;
 import com.backend.global.security.config.SecurityConfig;
-import com.backend.global.security.dto.LoginMember;
+import com.backend.global.security.exception.InvalidTokenException;
 import com.backend.global.security.util.JwtUtil;
-import com.backend.member.dto.MemberProfileResponse;
 import com.backend.member.dto.MemberSignupRequest;
 import com.backend.member.exception.DuplicateNicknameException;
 import com.backend.member.exception.DuplicateUsernameException;
@@ -13,29 +12,29 @@ import com.backend.token.service.TokenService;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 
-import java.nio.charset.StandardCharsets;
-
-import java.util.Date;
+import static com.backend.support.fixture.AuthFixture.LOGIN_MEMBER;
+import static com.backend.support.fixture.JwtFixture.ACCESS_TOKEN;
+import static com.backend.support.fixture.JwtFixture.REFRESH_TOKEN;
+import static com.backend.support.fixture.JwtFixture.INVALID_ACCESS_TOKEN;
+import static com.backend.support.fixture.JwtFixture.CLAIMS_FOR_ACCESS_TOKEN;
+import static com.backend.support.fixture.MemberFixture.MEMBER_PROFILE_RESPONSE;
+import static com.backend.support.fixture.MemberFixture.NICKNAME;
+import static com.backend.support.fixture.MemberFixture.USERNAME;
+import static com.backend.support.fixture.MemberFixture.PLAIN_PASSWORD;
+import static com.backend.support.fixture.MemberFixture.VALID_SIGNUP_REQUEST;
+import static com.backend.support.fixture.MemberFixture.INVALID_SIGNUP_REQUEST;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -54,15 +53,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = MemberController.class)
 @Import(SecurityConfig.class)
 class MemberControllerTest {
-
-    private static final Long ID = 1L;
-    private static final String NICKNAME = "민수쿤";
-    private static final String USERNAME = "yoonms0617";
-    private static final String PASSWORD = "1q2w3e4r!";
-    private static final String ROLE = "ROLE_MEMBER";
-
-    @Value("${jwt.secret-key}")
-    private String secretKey;
 
     @Autowired
     private MockMvc mockMvc;
@@ -85,15 +75,11 @@ class MemberControllerTest {
     @Test
     @DisplayName("정상적으로 회원가입에 성공한다.")
     void signup_request_test() throws Exception {
-        MemberSignupRequest request = new MemberSignupRequest(NICKNAME, USERNAME, PASSWORD);
-
         willDoNothing().given(memberService).signup(any(MemberSignupRequest.class));
 
-        ResultActions resultActions = mockMvc.perform(post("/api/member/signup")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(request)));
-
-        resultActions
+        mockMvc.perform(post("/api/member/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(VALID_SIGNUP_REQUEST)))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -101,16 +87,13 @@ class MemberControllerTest {
     @Test
     @DisplayName("입력 값이 잘못된 경우 회원가입에 실패한다.")
     void signup_request_invalid_input_value_test() throws Exception {
-        MemberSignupRequest request = new MemberSignupRequest("", "", "");
         ErrorType errorType = ErrorType.INVALID_INPUT_VALUE;
 
         willDoNothing().given(memberService).signup(any(MemberSignupRequest.class));
 
-        ResultActions resultActions = mockMvc.perform(post("/api/member/signup")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(request)));
-
-        resultActions
+        mockMvc.perform(post("/api/member/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(INVALID_SIGNUP_REQUEST)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(errorType.getCode()))
@@ -123,10 +106,8 @@ class MemberControllerTest {
     void exists_nickname_request_test() throws Exception {
         willDoNothing().given(memberService).existsNickname(anyString());
 
-        ResultActions resultActions = mockMvc.perform(get("/api/member/nickname/exists")
-                .param("nickname", NICKNAME));
-
-        resultActions
+        mockMvc.perform(get("/api/member/nickname/exists")
+                        .param("nickname", NICKNAME))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().string("Y"));
@@ -137,10 +118,8 @@ class MemberControllerTest {
     void exists_username_request_test() throws Exception {
         willDoNothing().given(memberService).existsUsername(anyString());
 
-        ResultActions resultActions = mockMvc.perform(get("/api/member/username/exists")
-                .param("username", USERNAME));
-
-        resultActions
+        mockMvc.perform(get("/api/member/username/exists")
+                        .param("username", USERNAME))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().string("Y"));
@@ -149,16 +128,14 @@ class MemberControllerTest {
     @Test
     @DisplayName("닉네임이 중복될시 회원가입에 실패한다.")
     void signup_request_duplicate_nickname_test() throws Exception {
-        MemberSignupRequest request = new MemberSignupRequest(NICKNAME, USERNAME, PASSWORD);
         ErrorType errorType = ErrorType.DUPLICATE_NICKNAME;
 
-        willThrow(new DuplicateNicknameException(ErrorType.DUPLICATE_NICKNAME)).given(memberService).signup(any(MemberSignupRequest.class));
+        willThrow(new DuplicateNicknameException(ErrorType.DUPLICATE_NICKNAME)).given(memberService)
+                .signup(any(MemberSignupRequest.class));
 
-        ResultActions resultActions = mockMvc.perform(post("/api/member/signup")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(request)));
-
-        resultActions
+        mockMvc.perform(post("/api/member/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(VALID_SIGNUP_REQUEST)))
                 .andDo(print())
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value(errorType.getCode()))
@@ -169,16 +146,13 @@ class MemberControllerTest {
     @Test
     @DisplayName("아이디가 중복될시 회원가입에 실패한다.")
     void signup_request_duplicate_username_test() throws Exception {
-        MemberSignupRequest request = new MemberSignupRequest(NICKNAME, USERNAME, PASSWORD);
         ErrorType errorType = ErrorType.DUPLICATE_USERNAME;
 
         willThrow(new DuplicateUsernameException(ErrorType.DUPLICATE_USERNAME)).given(memberService).signup(any(MemberSignupRequest.class));
 
-        ResultActions resultActions = mockMvc.perform(post("/api/member/signup")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(request)));
-
-        resultActions
+        mockMvc.perform(post("/api/member/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(VALID_SIGNUP_REQUEST)))
                 .andDo(print())
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.code").value(errorType.getCode()))
@@ -189,43 +163,19 @@ class MemberControllerTest {
     @Test
     @DisplayName("정상적으로 로그인에 성공하면 Access Token과 Refresh Token을 응답한다.")
     void login_request_test() throws Exception {
-        String encoded = PasswordEncoderFactories.createDelegatingPasswordEncoder().encode(PASSWORD);
-        LoginMember loginMember = new LoginMember(ID, NICKNAME, USERNAME, encoded, ROLE);
-        Date iat = new Date();
-        String accessToken = Jwts.builder()
-                .setSubject(String.valueOf(ID))
-                .claim("nickname", NICKNAME)
-                .claim("username", USERNAME)
-                .claim("role", ROLE)
-                .setIssuedAt(iat)
-                .setExpiration(new Date(iat.getTime() + 600000))
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
-                .compact();
-        String refreshToken = Jwts.builder()
-                .setSubject(String.valueOf(ID))
-                .claim("nickname", NICKNAME)
-                .claim("username", USERNAME)
-                .claim("role", ROLE)
-                .setIssuedAt(iat)
-                .setExpiration(new Date(iat.getTime() + 3600000))
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
-                .compact();
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(LOGIN_MEMBER);
+        given(jwtUtil.createAccessToken(anyLong(), anyString(), anyString(), anyString())).willReturn(ACCESS_TOKEN);
+        given(jwtUtil.createRefreshToken(anyLong(), anyString(), anyString(), anyString())).willReturn(REFRESH_TOKEN);
 
-        given(userDetailsService.loadUserByUsername(anyString())).willReturn(loginMember);
-        given(jwtUtil.createAccessToken(anyLong(), anyString(), anyString(), anyString())).willReturn(accessToken);
-        given(jwtUtil.createRefreshToken(anyLong(), anyString(), anyString(), anyString())).willReturn(refreshToken);
-
-        ResultActions resultActions = mockMvc.perform(post("/api/auth/login")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("username", USERNAME)
-                .param("password", PASSWORD));
-
-        resultActions
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("username", "yoonms0617")
+                        .param("password", "1q2w3e4r!"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.nickname").value(NICKNAME))
-                .andExpect(jsonPath("$.token.accessToken").value(accessToken))
-                .andExpect(jsonPath("$.token.refreshToken").value(refreshToken));
+                .andExpect(jsonPath("$.token.accessToken").value(ACCESS_TOKEN))
+                .andExpect(jsonPath("$.token.refreshToken").value(REFRESH_TOKEN));
     }
 
     @Test
@@ -235,12 +185,10 @@ class MemberControllerTest {
 
         willThrow(UsernameNotFoundException.class).given(userDetailsService).loadUserByUsername(anyString());
 
-        ResultActions resultActions = mockMvc.perform(post("/api/auth/login")
-                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                .param("username", USERNAME)
-                .param("password", PASSWORD));
-
-        resultActions
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                        .param("username", USERNAME)
+                        .param("password", PLAIN_PASSWORD))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(errorType.getCode()))
@@ -251,47 +199,34 @@ class MemberControllerTest {
     @Test
     @DisplayName("정상적으로 회원 정보를 조회한다.")
     void profile_request_test() throws Exception {
-        MemberProfileResponse response = new MemberProfileResponse(NICKNAME, USERNAME);
-        String encoded = PasswordEncoderFactories.createDelegatingPasswordEncoder().encode(PASSWORD);
-        LoginMember loginMember = new LoginMember(ID, NICKNAME, USERNAME, encoded, ROLE);
-        String accessToken = createAccessToken();
-        Claims claims = createClaims(accessToken);
+        given(userDetailsService.loadUserByUsername(anyString())).willReturn(LOGIN_MEMBER);
+        given(jwtUtil.createAccessToken(anyLong(), anyString(), anyString(), anyString())).willReturn(ACCESS_TOKEN);
+        given(jwtUtil.getPayload(anyString())).willReturn(CLAIMS_FOR_ACCESS_TOKEN);
+        given(memberService.profile(anyString())).willReturn(MEMBER_PROFILE_RESPONSE);
 
-        given(userDetailsService.loadUserByUsername(anyString())).willReturn(loginMember);
-        given(jwtUtil.createAccessToken(anyLong(), anyString(), anyString(), anyString())).willReturn(accessToken);
-        given(jwtUtil.getPayload(anyString())).willReturn(claims);
-        given(memberService.profile(anyString())).willReturn(response);
-
-        ResultActions resultActions = mockMvc.perform(get("/api/member/profile")
-                .header("Authorization", "Bearer " + accessToken)
-        );
-
-        resultActions
+        mockMvc.perform(get("/api/member/profile")
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.nickname").value(response.getNickname()))
-                .andExpect(jsonPath("$.username").value(response.getUsername()));
+                .andExpect(jsonPath("$.nickname").value(NICKNAME))
+                .andExpect(jsonPath("$.username").value(USERNAME));
     }
 
-    private String createAccessToken() {
-        Date iat = new Date();
-        Date exp = new Date(iat.getTime() + 600000);
-        return Jwts.builder()
-                .setSubject(String.valueOf(1L))
-                .claim("username", "yoonms0617")
-                .claim("role", "ROLE_MEMBER")
-                .setIssuedAt(iat)
-                .setExpiration(exp)
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
-                .compact();
-    }
+    @Test
+    @DisplayName("유효하지 않은 토큰으로 회원 정보를 조회할시 실패한다.")
+    void profile_invalid_token_request_test() throws Exception {
+        ErrorType errorType = ErrorType.INVALID_TOKEN;
 
-    private Claims createClaims(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+        willThrow(new InvalidTokenException(ErrorType.INVALID_TOKEN.getCode())).given(jwtUtil).validatedToken(anyString());
+
+        mockMvc.perform(get("/api/member/token")
+                        .header("Authorization", "Bearer " + INVALID_ACCESS_TOKEN)
+                )
+                .andDo(print())
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(errorType.getCode()))
+                .andExpect(jsonPath("$.status").value(errorType.getStatus()))
+                .andExpect(jsonPath("$.message").value(errorType.getMessage()));
     }
 
 }

--- a/backend/src/test/java/com/backend/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/backend/member/repository/MemberRepositoryTest.java
@@ -9,9 +9,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 
 import java.util.Optional;
+
+import static com.backend.support.fixture.MemberFixture.ENCODED_PASSWORD;
+import static com.backend.support.fixture.MemberFixture.NICKNAME;
+import static com.backend.support.fixture.MemberFixture.USERNAME;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,17 +22,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Import(JpaAuditConfig.class)
 class MemberRepositoryTest {
 
-    private static final String NICKNAME = "민수쿤";
-    private static final String USERNAME = "yoonms0617";
-    private static final String PASSWORD = PasswordEncoderFactories.createDelegatingPasswordEncoder().encode("1q2w3e4r!");
-
     @Autowired
     private MemberRepository memberRepository;
 
     @Test
     @DisplayName("회원을 저장한다.")
     void member_save_test() {
-        Member member = new Member(NICKNAME, USERNAME, PASSWORD);
+        Member member = new Member(NICKNAME, USERNAME, ENCODED_PASSWORD);
 
         Long id = memberRepository.save(member).getId();
 
@@ -39,34 +38,34 @@ class MemberRepositoryTest {
     @Test
     @DisplayName("식별자로 회원을 조회한다.")
     void member_findById_test() {
-        Member member = new Member(NICKNAME, USERNAME, PASSWORD);
-        Member save = memberRepository.save(member);
+        Member member = new Member(NICKNAME, USERNAME, ENCODED_PASSWORD);
+        Member expected = memberRepository.save(member);
 
-        Optional<Member> find = memberRepository.findById(save.getId());
+        Optional<Member> actual = memberRepository.findById(expected.getId());
 
-        assertThat(find).isPresent();
-        assertThat(find.get()).usingRecursiveComparison().isEqualTo(save);
+        assertThat(actual).isPresent();
+        assertThat(actual.get()).usingRecursiveComparison().isEqualTo(expected);
     }
 
     @Test
     @DisplayName("아이디로 회원을 조회한다.")
     void member_findbyUsername_test() {
-        Member member = new Member(NICKNAME, USERNAME, PASSWORD);
-        Member save = memberRepository.save(member);
+        Member member = new Member(NICKNAME, USERNAME, ENCODED_PASSWORD);
+        Member expected = memberRepository.save(member);
 
-        Optional<Member> find = memberRepository.findByUsername(save.getUsername());
+        Optional<Member> actual = memberRepository.findByUsername(expected.getUsername());
 
-        assertThat(find).isPresent();
-        assertThat(find.get()).usingRecursiveComparison().isEqualTo(save);
+        assertThat(actual).isPresent();
+        assertThat(actual.get()).usingRecursiveComparison().isEqualTo(expected);
     }
 
     @Test
     @DisplayName("닉네임의 존재 여부를 확인한다.")
     void member_existsByNickname_test() {
-        Member member = new Member(NICKNAME, USERNAME, PASSWORD);
+        Member member = new Member(NICKNAME, USERNAME, ENCODED_PASSWORD);
         memberRepository.save(member);
 
-        boolean exists = memberRepository.existsByNickname(member.getNickname());
+        boolean exists = memberRepository.existsByNickname(NICKNAME);
 
         assertThat(exists).isTrue();
     }
@@ -74,10 +73,10 @@ class MemberRepositoryTest {
     @Test
     @DisplayName("아이디의 존재 여부를 확인한다.")
     void member_existsByUsername_test() {
-        Member member = new Member(NICKNAME, USERNAME, PASSWORD);
+        Member member = new Member(NICKNAME, USERNAME, ENCODED_PASSWORD);
         memberRepository.save(member);
 
-        boolean exists = memberRepository.existsByUsername(member.getUsername());
+        boolean exists = memberRepository.existsByUsername(USERNAME);
 
         assertThat(exists).isTrue();
     }

--- a/backend/src/test/java/com/backend/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/backend/post/controller/PostControllerTest.java
@@ -3,40 +3,38 @@ package com.backend.post.controller;
 import com.backend.global.error.exception.ErrorType;
 import com.backend.global.security.config.SecurityConfig;
 import com.backend.global.security.util.JwtUtil;
-import com.backend.post.dto.PostDetailResponse;
 import com.backend.post.dto.PostItem;
 import com.backend.post.dto.PostListResponse;
 import com.backend.post.dto.PostWriteRequest;
 import com.backend.post.exception.NotFoundPostException;
 import com.backend.post.service.PostService;
-
 import com.backend.token.service.TokenService;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
-
-import java.nio.charset.StandardCharsets;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
+
+import static com.backend.support.fixture.JwtFixture.ACCESS_TOKEN;
+import static com.backend.support.fixture.JwtFixture.CLAIMS_FOR_ACCESS_TOKEN;
+import static com.backend.support.fixture.MemberFixture.NICKNAME;
+import static com.backend.support.fixture.PostFixture.CONTENT;
+import static com.backend.support.fixture.PostFixture.INVALID_POST_WRITE_REQUEST;
+import static com.backend.support.fixture.PostFixture.POST_DETAIL_RESPONSE;
+import static com.backend.support.fixture.PostFixture.TITLE;
+import static com.backend.support.fixture.PostFixture.VALID_POST_WRITE_REQUEST;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -44,8 +42,8 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
-
 import static org.mockito.BDDMockito.willThrow;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -55,12 +53,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(controllers = PostController.class)
 @Import(SecurityConfig.class)
 class PostControllerTest {
-
-    private static final String TITLE = "title";
-    private static final String CONTENT = "content";
-
-    @Value("${jwt.secret-key}")
-    private String secretKey;
 
     @Autowired
     private MockMvc mockMvc;
@@ -83,20 +75,14 @@ class PostControllerTest {
     @Test
     @DisplayName("게시글을 작성한다.")
     void write_request_test() throws Exception {
-        String accessToken = createAccessToken();
-        Claims claims = createClaims(accessToken);
-        PostWriteRequest request = new PostWriteRequest(TITLE, CONTENT);
-
         willDoNothing().given(jwtUtil).validatedToken(anyString());
-        given(jwtUtil.getPayload(anyString())).willReturn(claims);
+        given(jwtUtil.getPayload(anyString())).willReturn(CLAIMS_FOR_ACCESS_TOKEN);
         willDoNothing().given(postService).write(anyString(), any(PostWriteRequest.class));
 
-        ResultActions resultActions = mockMvc.perform(post("/api/post/write")
-                .header("Authorization", "Bearer " + accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(request)));
-
-        resultActions
+        mockMvc.perform(post("/api/post/write")
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(VALID_POST_WRITE_REQUEST)))
                 .andDo(print())
                 .andExpect(status().isOk());
     }
@@ -104,19 +90,14 @@ class PostControllerTest {
     @Test
     @DisplayName("입력 값이 잘못된 경우 게시글 작성에 실패한다.")
     void write_request_invalid_input_value_test() throws Exception {
-        String accessToken = createAccessToken();
-        Claims claims = createClaims(accessToken);
-        PostWriteRequest request = new PostWriteRequest("", "");
         ErrorType errorType = ErrorType.INVALID_INPUT_VALUE;
 
-        given(jwtUtil.getPayload(anyString())).willReturn(claims);
+        given(jwtUtil.getPayload(anyString())).willReturn(CLAIMS_FOR_ACCESS_TOKEN);
 
-        ResultActions resultActions = mockMvc.perform(post("/api/post/write")
-                .header("Authorization", "Bearer " + accessToken)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsBytes(request)));
-
-        resultActions
+        mockMvc.perform(post("/api/post/write")
+                        .header("Authorization", "Bearer " + ACCESS_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(INVALID_POST_WRITE_REQUEST)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(errorType.getCode()))
@@ -136,10 +117,8 @@ class PostControllerTest {
         PostListResponse response = new PostListResponse(postItems, 1, true, true);
         given(postService.list(anyInt())).willReturn(response);
 
-        ResultActions resultActions = mockMvc.perform(get("/api/post/list")
-                .param("page", "1"));
-
-        resultActions
+        mockMvc.perform(get("/api/post/list")
+                        .param("page", "1"))
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.posts").isArray())
@@ -154,19 +133,15 @@ class PostControllerTest {
     @Test
     @DisplayName("게시글을 상세 조회한다.")
     void detail_request_test() throws Exception {
-        PostDetailResponse response = new PostDetailResponse(1L, "title", "writer", "content", LocalDateTime.now());
+        given(postService.detail(anyLong())).willReturn(POST_DETAIL_RESPONSE);
 
-        given(postService.detail(anyLong())).willReturn(response);
-
-        ResultActions resultActions = mockMvc.perform(get("/api/post/detail/1"));
-
-        resultActions
+        mockMvc.perform(get("/api/post/detail/1"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.postNum").value(response.getPostNum()))
-                .andExpect(jsonPath("$.title").value(response.getTitle()))
-                .andExpect(jsonPath("$.writer").value(response.getWriter()))
-                .andExpect(jsonPath("$.content").value(response.getContent()));
+                .andExpect(jsonPath("$.postNum").value(1L))
+                .andExpect(jsonPath("$.title").value(TITLE))
+                .andExpect(jsonPath("$.writer").value(NICKNAME))
+                .andExpect(jsonPath("$.content").value(CONTENT));
     }
 
     @Test
@@ -176,35 +151,12 @@ class PostControllerTest {
 
         willThrow(new NotFoundPostException(ErrorType.NOT_FOUND_POST)).given(postService).detail(anyLong());
 
-        ResultActions resultActions = mockMvc.perform(get("/api/post/detail/1"));
-
-        resultActions
+        mockMvc.perform(get("/api/post/detail/1"))
                 .andDo(print())
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(errorType.getCode()))
                 .andExpect(jsonPath("$.status").value(errorType.getStatus()))
                 .andExpect(jsonPath("$.message").value(errorType.getMessage()));
-    }
-
-    private String createAccessToken() {
-        Date iat = new Date();
-        Date exp = new Date(iat.getTime() + 600000);
-        return Jwts.builder()
-                .setSubject(String.valueOf(1L))
-                .claim("username", "yoonms0617")
-                .claim("role", "ROLE_MEMBER")
-                .setIssuedAt(iat)
-                .setExpiration(exp)
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
-                .compact();
-    }
-
-    private Claims createClaims(String token) {
-        return Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8)))
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
     }
 
 }

--- a/backend/src/test/java/com/backend/post/repository/PostRepositoryTest.java
+++ b/backend/src/test/java/com/backend/post/repository/PostRepositoryTest.java
@@ -20,14 +20,17 @@ import org.springframework.data.domain.Sort;
 import java.util.List;
 import java.util.Optional;
 
+import static com.backend.support.fixture.MemberFixture.NICKNAME;
+import static com.backend.support.fixture.MemberFixture.USERNAME;
+import static com.backend.support.fixture.MemberFixture.ENCODED_PASSWORD;
+import static com.backend.support.fixture.PostFixture.CONTENT;
+import static com.backend.support.fixture.PostFixture.TITLE;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DataJpaTest
 @Import(JpaAuditConfig.class)
 class PostRepositoryTest {
-
-    private static final String TITLE = "title";
-    private static final String CONTENT = "content";
 
     @Autowired
     private PostRepository postRepository;
@@ -39,14 +42,14 @@ class PostRepositoryTest {
 
     @BeforeEach
     void setUp() {
-        member = new Member("민수쿤", "yoonms0617", "1q2w3e4r!");
+        member = new Member(NICKNAME, USERNAME, ENCODED_PASSWORD);
         memberRepository.save(member);
     }
 
     @Test
     @DisplayName("게시글을 저장한다.")
     void post_save_test() {
-        Post post = new Post(TITLE, member.getNickname(), CONTENT, member);
+        Post post = new Post(TITLE, NICKNAME, CONTENT, member);
 
         Post save = postRepository.save(post);
 
@@ -54,34 +57,35 @@ class PostRepositoryTest {
     }
 
     @Test
+    @DisplayName("식별자로 게시글을 조회한다.")
+    void post_findById_test() {
+        Post post = new Post(TITLE, NICKNAME, CONTENT, member);
+        Post expected = postRepository.save(post);
+
+        Optional<Post> actual = postRepository.findById(expected.getId());
+
+        assertThat(actual).isPresent();
+        assertThat(actual.get()).usingRecursiveComparison().isEqualTo(expected);
+    }
+
+    @Test
     @DisplayName("게시글 목록을 조회한다.")
     void post_findAll_test() {
-        Post postA = new Post(TITLE, member.getNickname(), CONTENT, member);
-        Post postB = new Post(TITLE, member.getNickname(), CONTENT, member);
-        Post postC = new Post(TITLE, member.getNickname(), CONTENT, member);
-        Post postD = new Post(TITLE, member.getNickname(), CONTENT, member);
-        Post postE = new Post(TITLE, member.getNickname(), CONTENT, member);
+        Post postA = new Post(TITLE, NICKNAME, CONTENT, member);
+        Post postB = new Post(TITLE, NICKNAME, CONTENT, member);
+        Post postC = new Post(TITLE, NICKNAME, CONTENT, member);
+        Post postD = new Post(TITLE, NICKNAME, CONTENT, member);
+        Post postE = new Post(TITLE, NICKNAME, CONTENT, member);
+
         postRepository.saveAll(List.of(postA, postB, postC, postD, postE));
 
-        Pageable pageable = PageRequest.of(0, 10, Sort.Direction.DESC, "id");
+        Pageable pageable = PageRequest.of(0, 5, Sort.Direction.DESC, "id");
         Page<Post> posts = postRepository.findAll(pageable);
 
         assertThat(posts.getContent()).containsExactly(postE, postD, postC, postB, postA);
         assertThat(posts.getContent().size()).isEqualTo(5);
         assertThat(posts.getTotalElements()).isEqualTo(5);
         assertThat(posts.getNumber()).isEqualTo(0);
-    }
-
-    @Test
-    @DisplayName("식별자로 게시글을 조회한다.")
-    void post_findById_test() {
-        Post post = new Post(TITLE, member.getNickname(), CONTENT, member);
-        Post save = postRepository.save(post);
-
-        Optional<Post> find = postRepository.findById(save.getId());
-
-        assertThat(find).isPresent();
-        assertThat(find.get()).usingRecursiveComparison().isEqualTo(save);
     }
 
 }

--- a/backend/src/test/java/com/backend/support/fixture/AuthFixture.java
+++ b/backend/src/test/java/com/backend/support/fixture/AuthFixture.java
@@ -1,0 +1,30 @@
+package com.backend.support.fixture;
+
+import com.backend.global.security.dto.LoginMember;
+import com.backend.token.domain.Token;
+import com.backend.token.dto.TokenResponse;
+
+import static com.backend.support.fixture.JwtFixture.ACCESS_TOKEN;
+import static com.backend.support.fixture.JwtFixture.REFRESH_TOKEN;
+
+import static org.springframework.security.crypto.factory.PasswordEncoderFactories.createDelegatingPasswordEncoder;
+
+public final class AuthFixture {
+
+    private static final Long MEMBER_ID = 1L;
+    private static final String NICKNAME = "민수쿤";
+    private static final String USERNAME = "yoonms0617";
+    private static final String ENCODED_PASSWORD = createDelegatingPasswordEncoder().encode("1q2w3e4r!");
+    private static final String ROLE = "ROLE_MEMBER";
+
+    public static LoginMember LOGIN_MEMBER = new LoginMember(MEMBER_ID, NICKNAME, USERNAME, ENCODED_PASSWORD, ROLE);
+    public static TokenResponse TOKEN_RESPONSE = new TokenResponse(ACCESS_TOKEN);
+
+    public static Token TOKEN = Token.builder()
+            .username(USERNAME)
+            .refreshToken(REFRESH_TOKEN)
+            .memberId(MEMBER_ID)
+            .build();
+
+
+}

--- a/backend/src/test/java/com/backend/support/fixture/JwtFixture.java
+++ b/backend/src/test/java/com/backend/support/fixture/JwtFixture.java
@@ -1,0 +1,52 @@
+package com.backend.support.fixture;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Date;
+
+public final class JwtFixture {
+
+    private static final String EMPTY_VALUE = "";
+    private static final Long ID = 1L;
+    private static final String NICKNAME = "민수쿤";
+    private static final String USERNAME = "yoonms0617";
+    private static final String ROLE = "ROLE_MEMBER";
+    private static final String SECRET_KEY = "this-is-jwt-fixture-test-secret-key";
+    private static final long ACCESS_TOKEN_IN_MILLISECONDS = 600000;
+    private static final long REFRESH_TOKEN_IN_MILLISECONDS = 3600000;
+
+    public static String ACCESS_TOKEN = createToken(ACCESS_TOKEN_IN_MILLISECONDS);
+    public static String REFRESH_TOKEN = createToken(REFRESH_TOKEN_IN_MILLISECONDS);
+    public static String INVALID_ACCESS_TOKEN = EMPTY_VALUE;
+    public static String INVALID_REFRESH_TOKEN = EMPTY_VALUE;
+    public static Claims CLAIMS_FOR_ACCESS_TOKEN = claims(ACCESS_TOKEN);
+    public static Claims CLAIMS_FOR_REFRESH_TOKEN = claims(REFRESH_TOKEN);
+
+    private static String createToken(long tokenInMilliseconds) {
+        Date iat = new Date();
+        Date exp = new Date(iat.getTime() + tokenInMilliseconds);
+        return Jwts.builder()
+                .setSubject(String.valueOf(ID))
+                .claim("nickname", NICKNAME)
+                .claim("username", USERNAME)
+                .claim("role", ROLE)
+                .setIssuedAt(iat)
+                .setExpiration(exp)
+                .signWith(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    private static Claims claims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(Keys.hmacShaKeyFor(SECRET_KEY.getBytes(StandardCharsets.UTF_8)))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+}

--- a/backend/src/test/java/com/backend/support/fixture/MemberFixture.java
+++ b/backend/src/test/java/com/backend/support/fixture/MemberFixture.java
@@ -1,0 +1,29 @@
+package com.backend.support.fixture;
+
+import com.backend.member.domain.Member;
+import com.backend.member.dto.MemberProfileResponse;
+import com.backend.member.dto.MemberSignupRequest;
+
+import static org.springframework.security.crypto.factory.PasswordEncoderFactories.createDelegatingPasswordEncoder;
+
+public final class MemberFixture {
+
+    private static final String EMPTY_VALUE = "";
+
+    public static final Long MEMBER_ID = 1L;
+    public static final String NICKNAME = "민수쿤";
+    public static final String USERNAME = "yoonms0617";
+    public static final String PLAIN_PASSWORD = "1q2w3e4r!";
+    public static final String ENCODED_PASSWORD = createDelegatingPasswordEncoder().encode(PLAIN_PASSWORD);
+
+    public static final MemberSignupRequest VALID_SIGNUP_REQUEST = new MemberSignupRequest(NICKNAME, USERNAME, PLAIN_PASSWORD);
+    public static final MemberSignupRequest INVALID_SIGNUP_REQUEST = new MemberSignupRequest(EMPTY_VALUE, EMPTY_VALUE, EMPTY_VALUE);
+    public static final MemberProfileResponse MEMBER_PROFILE_RESPONSE = new MemberProfileResponse(NICKNAME, USERNAME);
+
+    public static final Member MEMBER = Member.builder()
+            .nickname(NICKNAME)
+            .username(USERNAME)
+            .password(ENCODED_PASSWORD)
+            .build();
+
+}

--- a/backend/src/test/java/com/backend/support/fixture/PostFixture.java
+++ b/backend/src/test/java/com/backend/support/fixture/PostFixture.java
@@ -1,0 +1,29 @@
+package com.backend.support.fixture;
+
+import com.backend.post.domain.Post;
+import com.backend.post.dto.PostDetailResponse;
+import com.backend.post.dto.PostWriteRequest;
+
+import java.time.LocalDateTime;
+
+import static com.backend.support.fixture.MemberFixture.MEMBER;
+import static com.backend.support.fixture.MemberFixture.NICKNAME;
+
+public class PostFixture {
+
+    private static final String EMPTY_VALUE = "";
+    public static final String TITLE = "Hello";
+    public static final String CONTENT = "World";
+
+    public static PostWriteRequest VALID_POST_WRITE_REQUEST = new PostWriteRequest(TITLE, CONTENT);
+    public static PostWriteRequest INVALID_POST_WRITE_REQUEST = new PostWriteRequest(EMPTY_VALUE, EMPTY_VALUE);
+    public static PostDetailResponse POST_DETAIL_RESPONSE = new PostDetailResponse(1L, TITLE, NICKNAME, CONTENT, LocalDateTime.now());
+
+    public static Post POST = Post.builder()
+            .title(TITLE)
+            .writer(NICKNAME)
+            .content(CONTENT)
+            .member(MEMBER)
+            .build();
+
+}


### PR DESCRIPTION
## 작업 내용

테스트시 반복적으로 사용되는 객체 분리

### 세부 구현기능

- Test Fixture 클래스를 만들어 반복적으로 사용되는 객체를 미리 정의해 사용하도록 변경
- 인증 실패시 인증 실패 핸들러에서 401 상태코드 응답하도록 변경

#### 관련 이슈

(이렇게 사용하는게 맞는지 모르겠다..)

close #36 
