### PR TITLE
[FE] 라우터 분리

### DIFF
--- a/frontend/src/constants/message.js
+++ b/frontend/src/constants/message.js
@@ -7,7 +7,7 @@ const CLIENT_MESSAGE = {
   GOOD_USERNAME: "사용 가능한 아이디입니다.",
   GOOD_PASSWORD: "사용 가능한 비밀번호입니다.",
   GOOD_CONFIRM: "비밀번호가 일치합니다.",
-  REQUIRE_LOGIN: "로그인이 필요합니다.",
+  REQUIRE_LOGIN: "로그인 후 이용할 수 있는 서비스입니다. 로그인하시겠습니까?.",
   INPUT_POST_TITLE: "제목을 입력해 주세요.",
   INPUT_POST_CONTNET: "내용을 입력해 주세요.",
 };

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,75 +1,17 @@
 import { createRouter, createWebHistory } from "vue-router";
-import HomeView from "@/views/HomeView.vue";
-import LoginView from "@/views/member/LoginView.vue";
-import SignupView from "@/views/member/SignupView.vue";
-import WriteView from "@/views/post/WriteView.vue";
-import DetailView from "@/views/post/DetailView.vue";
-import UpdateView from "@/views/post/UpdateView.vue";
-
-import { CLIENT_MESSAGE } from "@/constants/message";
-
-const ACCESS_TOKEN_KEY = process.env.VUE_APP_ACCESS_TOKEN_KEY;
-
-function isLogin(to, from, next) {
-  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
-  if (accessToken) {
-    next({
-      name: "home",
-    });
-  } else {
-    next();
-  }
-}
-
-function requireLogin(to, from, next) {
-  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
-  if (!accessToken) {
-    alert(CLIENT_MESSAGE.REQUIRE_LOGIN);
-    next("/login");
-  } else {
-    next();
-  }
-}
+import memberRoutes from "@/router/member/member-router";
+import postRoutes from "@/router/post/post-router";
 
 const routes = [
   {
     path: "/",
-    name: "home",
-    component: HomeView,
-  },
-  {
-    path: "/login",
-    name: "login",
-    component: LoginView,
-    beforeEnter: isLogin,
-  },
-  {
-    path: "/signup",
-    name: "signup",
-    component: SignupView,
-    beforeEnter: isLogin,
-  },
-  {
-    path: "/post/write",
-    name: "write",
-    component: WriteView,
-    beforeEnter: requireLogin,
-  },
-  {
-    path: "/post/detail/:postNum",
-    name: "detail",
-    component: DetailView,
-  },
-  {
-    path: "/post/update/:postNum",
-    name: "update",
-    component: UpdateView,
+    component: () => import("@/views/HomeView.vue"),
   },
 ];
 
 const router = createRouter({
   history: createWebHistory(process.env.BASE_URL),
-  routes,
+  routes: [...routes, ...memberRoutes, ...postRoutes],
 });
 
 export default router;

--- a/frontend/src/router/member/member-router.js
+++ b/frontend/src/router/member/member-router.js
@@ -1,0 +1,25 @@
+const ACCESS_TOKEN_KEY = process.env.VUE_APP_ACCESS_TOKEN_KEY;
+
+function checkLogin(to, from, next) {
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+  if (accessToken) {
+    next("/");
+  } else {
+    next();
+  }
+}
+
+const memberRoutes = [
+  {
+    path: "/login",
+    component: () => import("@/views/member/LoginView.vue"),
+    beforeEnter: checkLogin,
+  },
+  {
+    path: "/signup",
+    component: () => import("@/views/member/SignupView.vue"),
+    beforeEnter: checkLogin,
+  },
+];
+
+export default memberRoutes;

--- a/frontend/src/router/post/post-router.js
+++ b/frontend/src/router/post/post-router.js
@@ -1,0 +1,37 @@
+import { CLIENT_MESSAGE } from "@/constants/message";
+
+const ACCESS_TOKEN_KEY = process.env.VUE_APP_ACCESS_TOKEN_KEY;
+
+function requiresAuth(to, from, next) {
+  const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY);
+  if (!accessToken) {
+    const flag = confirm(CLIENT_MESSAGE.REQUIRE_LOGIN);
+    if (flag) {
+      next("/login");
+    } else {
+      next(from.path);
+    }
+  } else {
+    next();
+  }
+}
+
+const postRoutes = [
+  {
+    path: "/post/write",
+    component: () => import("@/views/post/WriteView.vue"),
+    beforeEnter: requiresAuth,
+  },
+  {
+    path: "/post/detail/:postNum",
+    component: () => import("@/views/post/DetailView.vue"),
+    beforeEnter: requiresAuth,
+  },
+  {
+    path: "/post/update/:postNum",
+    component: () => import("@/views/post/UpdateView.vue"),
+    beforeEnter: requiresAuth,
+  },
+];
+
+export default postRoutes;


### PR DESCRIPTION
## 작업 내용

한 파일에 모두 몰려있는 라우터 기능을 역할에 맞게 member와 post 라우터로 분리

### 세부 구현기능

- member 라우터와 post 라우터로 분리
- 로그인이 필요한 경로 이동 시 네비게이션 가드를 이용해 로그인 상태 검사
- 로그인 필요 알림 메시지 변경

#### 관련 이슈

close #48
