### PR TITLE
[BE] 회원가입 기능 구현

### DIFF
--- a/backend/src/main/java/com/board/global/config/JpaAuditConfig.java
+++ b/backend/src/main/java/com/board/global/config/JpaAuditConfig.java
@@ -1,0 +1,9 @@
+package com.board.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+}

--- a/backend/src/main/java/com/board/global/domain/BaseEntity.java
+++ b/backend/src/main/java/com/board/global/domain/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.board.global.domain;
+
+import lombok.Getter;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+
+    @Column(nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(nullable = false)
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+}

--- a/backend/src/main/java/com/board/global/error/exception/ErrorType.java
+++ b/backend/src/main/java/com/board/global/error/exception/ErrorType.java
@@ -2,10 +2,14 @@ package com.board.global.error.exception;
 
 import lombok.Getter;
 
+import org.springframework.http.HttpStatus;
+
 @Getter
 public enum ErrorType {
 
-    ;
+    INVALID_INPUT_VALUE("ERR-COMMON001", HttpStatus.BAD_REQUEST.value()),
+    DUPLICATE_NICKNAME("ERR-USER001", HttpStatus.CONFLICT.value()),
+    DUPLICATE_USERNAME("ERR-USER002", HttpStatus.CONFLICT.value());
 
     private final String code;
     private final int status;

--- a/backend/src/main/java/com/board/global/error/handler/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/board/global/error/handler/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.board.global.error.exception.BaseException;
 import com.board.global.error.exception.ErrorType;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -16,6 +17,13 @@ public class GlobalExceptionHandler {
         ErrorType errorType = e.getErrorType();
         ErrorResponse errorResponse = ErrorResponse.of(errorType);
         return ResponseEntity.status(errorType.getStatus()).body(errorResponse);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException() {
+        ErrorType errorType = ErrorType.INVALID_INPUT_VALUE;
+        ErrorResponse errorResponse = ErrorResponse.of(errorType);
+        return ResponseEntity.badRequest().body(errorResponse);
     }
 
 }

--- a/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/board/global/security/config/SecurityConfig.java
@@ -1,0 +1,30 @@
+package com.board.global.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity
+                .csrf().disable()
+                .httpBasic().disable()
+                .authorizeHttpRequests(auth -> auth
+                        .antMatchers("/api/user/signup", "/api/user/check-nickname", "/api/user/check-username").permitAll()
+                        .anyRequest().authenticated()
+                );
+        return httpSecurity.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/backend/src/main/java/com/board/user/controller/UserController.java
+++ b/backend/src/main/java/com/board/user/controller/UserController.java
@@ -1,0 +1,43 @@
+package com.board.user.controller;
+
+import com.board.user.dto.UserSignupRequest;
+import com.board.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(@Valid @RequestBody UserSignupRequest dto) {
+        userService.signup(dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/check-nickname")
+    public ResponseEntity<String> checkNickname(@RequestParam("nickname") String nickname) {
+        userService.checkNickname(nickname);
+        return ResponseEntity.ok().body("Y");
+    }
+
+    @GetMapping("/check-username")
+    public ResponseEntity<String> checkUsername(@RequestParam("username") String username) {
+        userService.checkUsername(username);
+        return ResponseEntity.ok().body("Y");
+    }
+
+}

--- a/backend/src/main/java/com/board/user/domain/Role.java
+++ b/backend/src/main/java/com/board/user/domain/Role.java
@@ -1,0 +1,10 @@
+package com.board.user.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum Role {
+
+    ROLE_MEMBER
+
+}

--- a/backend/src/main/java/com/board/user/domain/User.java
+++ b/backend/src/main/java/com/board/user/domain/User.java
@@ -1,0 +1,49 @@
+package com.board.user.domain;
+
+import com.board.global.domain.BaseEntity;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Table(name = "USER_TABLE")
+@Entity
+@NoArgsConstructor
+@Getter
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false, unique = true)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Builder
+    public User(String nickname, String username, String password) {
+        this.nickname = nickname;
+        this.username = username;
+        this.password = password;
+        this.role = Role.ROLE_MEMBER;
+    }
+
+}

--- a/backend/src/main/java/com/board/user/dto/UserSignupRequest.java
+++ b/backend/src/main/java/com/board/user/dto/UserSignupRequest.java
@@ -1,0 +1,23 @@
+package com.board.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserSignupRequest {
+
+    @NotBlank
+    private String nickname;
+
+    @NotBlank
+    private String username;
+
+    @NotBlank
+    private String password;
+
+}

--- a/backend/src/main/java/com/board/user/exception/DuplicateNicknameException.java
+++ b/backend/src/main/java/com/board/user/exception/DuplicateNicknameException.java
@@ -1,0 +1,12 @@
+package com.board.user.exception;
+
+import com.board.global.error.exception.BaseException;
+import com.board.global.error.exception.ErrorType;
+
+public class DuplicateNicknameException extends BaseException {
+
+    public DuplicateNicknameException() {
+        super(ErrorType.DUPLICATE_NICKNAME);
+    }
+
+}

--- a/backend/src/main/java/com/board/user/exception/DuplicateUsernameException.java
+++ b/backend/src/main/java/com/board/user/exception/DuplicateUsernameException.java
@@ -1,0 +1,12 @@
+package com.board.user.exception;
+
+import com.board.global.error.exception.BaseException;
+import com.board.global.error.exception.ErrorType;
+
+public class DuplicateUsernameException extends BaseException {
+
+    public DuplicateUsernameException() {
+        super(ErrorType.DUPLICATE_USERNAME);
+    }
+
+}

--- a/backend/src/main/java/com/board/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/board/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.board.user.repository;
+
+import com.board.user.domain.User;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByNickname(String nickname);
+    boolean existsByUsername(String username);
+
+}

--- a/backend/src/main/java/com/board/user/service/UserService.java
+++ b/backend/src/main/java/com/board/user/service/UserService.java
@@ -1,0 +1,49 @@
+package com.board.user.service;
+
+import com.board.user.domain.User;
+import com.board.user.dto.UserSignupRequest;
+import com.board.user.exception.DuplicateNicknameException;
+import com.board.user.exception.DuplicateUsernameException;
+import com.board.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void signup(UserSignupRequest dto) {
+        checkNickname(dto.getNickname());
+        checkUsername(dto.getUsername());
+        String encoded = passwordEncoder.encode(dto.getPassword());
+        User user = User.builder()
+                .nickname(dto.getNickname())
+                .username(dto.getUsername())
+                .password(encoded)
+                .build();
+        userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public void checkNickname(String nickname) {
+        if (userRepository.existsByNickname(nickname)) {
+            throw new DuplicateNicknameException();
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void checkUsername(String username) {
+        if (userRepository.existsByUsername(username)) {
+            throw new DuplicateUsernameException();
+        }
+    }
+
+}

--- a/backend/src/test/java/com/board/user/controller/UserControllerTest.java
+++ b/backend/src/test/java/com/board/user/controller/UserControllerTest.java
@@ -1,0 +1,167 @@
+package com.board.user.controller;
+
+import com.board.global.security.config.SecurityConfig;
+import com.board.user.dto.UserSignupRequest;
+import com.board.user.exception.DuplicateNicknameException;
+import com.board.user.exception.DuplicateUsernameException;
+import com.board.user.service.UserService;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willDoNothing;
+
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = UserController.class)
+@ActiveProfiles(profiles = "test")
+@Import(SecurityConfig.class)
+class UserControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    @DisplayName("회원가입 요청을 정상적으로 처리한다")
+    void signup() throws Exception {
+        UserSignupRequest dto = new UserSignupRequest("yoonKun", "yoonms0617", "12345678");
+
+        willDoNothing().given(userService).signup(any(UserSignupRequest.class));
+
+        mockMvc.perform(post("/api/user/signup")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(objectMapper.writeValueAsBytes(dto))
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("잘못된 입력값으로 회원가입 요청시 예외 메시지를 응답한다")
+    void signup_invalidInputValue() throws Exception {
+        UserSignupRequest dto = new UserSignupRequest("", "", "12345678");
+
+        willDoNothing().given(userService).signup(any(UserSignupRequest.class));
+
+        mockMvc.perform(post("/api/user/signup")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(objectMapper.writeValueAsBytes(dto))
+                )
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("ERR-COMMON001"))
+                .andExpect(jsonPath("$.status").value("400"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원가입 요청시 닉네임이 중복되면 예외 메시지를 응답한다")
+    void signup_duplicateNickname() throws Exception {
+        UserSignupRequest dto = new UserSignupRequest("yoonKun", "yoonms0617", "12345678");
+
+        willThrow(new DuplicateNicknameException()).given(userService).signup(any(UserSignupRequest.class));
+
+        mockMvc.perform(post("/api/user/signup")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(objectMapper.writeValueAsBytes(dto))
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("ERR-USER001"))
+                .andExpect(jsonPath("$.status").value("409"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("회원가입 요청시 아이디가 중복되면 예외 메시지를 응답한다")
+    void signup_duplicateUsername() throws Exception {
+        UserSignupRequest dto = new UserSignupRequest("yoonKun", "yoonms0617", "12345678");
+
+        willThrow(new DuplicateUsernameException()).given(userService).signup(any(UserSignupRequest.class));
+
+        mockMvc.perform(post("/api/user/signup")
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .content(objectMapper.writeValueAsBytes(dto))
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("ERR-USER002"))
+                .andExpect(jsonPath("$.status").value("409"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 검사 요청을 정상적으로 처리한다")
+    void checkNickname() throws Exception {
+        willDoNothing().given(userService).checkNickname(any(String.class));
+
+        mockMvc.perform(get("/api/user/check-nickname")
+                        .param("nickname", "yoonKun")
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().string("Y"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("닉네임 중복 검사 요청시 중복되면 예외 메시지를 응답한다")
+    void checkNickname_duplicate() throws Exception {
+        willThrow(new DuplicateNicknameException()).given(userService).checkNickname(any(String.class));
+
+        mockMvc.perform(get("/api/user/check-nickname")
+                        .param("nickname", "yoonKun")
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("ERR-USER001"))
+                .andExpect(jsonPath("$.status").value("409"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("아이디 중복 검사 요청을 정상적으로 처리한다")
+    void checkUsername() throws Exception {
+        willDoNothing().given(userService).checkUsername(any(String.class));
+
+        mockMvc.perform(get("/api/user/check-username")
+                        .param("username", "yoonms0617")
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().string("Y"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("아이디 중복 검사 요청시 중복되면 예외 메시지를 응답한다")
+    void checkUsername_duplicate() throws Exception {
+        willThrow(new DuplicateUsernameException()).given(userService).checkUsername(any(String.class));
+
+        mockMvc.perform(get("/api/user/check-username")
+                        .param("username", "yoonms0617")
+                )
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("ERR-USER002"))
+                .andExpect(jsonPath("$.status").value("409"))
+                .andDo(print());
+    }
+
+}

--- a/backend/src/test/java/com/board/user/repository/UserRepositoryTest.java
+++ b/backend/src/test/java/com/board/user/repository/UserRepositoryTest.java
@@ -1,0 +1,56 @@
+package com.board.user.repository;
+
+import com.board.global.config.JpaAuditConfig;
+import com.board.user.domain.User;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@ActiveProfiles(profiles = "test")
+@Import(JpaAuditConfig.class)
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @DisplayName("회원을 저장한다")
+    void user_save() {
+        User user = new User("yoonKun", "yoonms0617", "12345678");
+
+        User actual = userRepository.save(user);
+
+        assertThat(actual.getId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("nickname의 존재 여부를 확인한다")
+    void user_existsByNickname() {
+        User user = new User("yoonKun", "yoonms0617", "12345678");
+        userRepository.save(user);
+
+        boolean actual = userRepository.existsByNickname("yoonKun");
+
+        assertThat(actual).isTrue();
+    }
+
+    @Test
+    @DisplayName("username의 존재 여부를 확인한다")
+    void user_existsByUsername() {
+        User user = new User("yoonKun", "yoonms0617", "12345678");
+        userRepository.save(user);
+
+        boolean actual = userRepository.existsByUsername("yoonms0617");
+
+        assertThat(actual).isTrue();
+    }
+
+}

--- a/backend/src/test/java/com/board/user/service/UserServiceTest.java
+++ b/backend/src/test/java/com/board/user/service/UserServiceTest.java
@@ -1,0 +1,138 @@
+package com.board.user.service;
+
+import com.board.user.domain.User;
+import com.board.user.dto.UserSignupRequest;
+import com.board.user.exception.DuplicateNicknameException;
+import com.board.user.exception.DuplicateUsernameException;
+import com.board.user.repository.UserRepository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles(profiles = "test")
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("회원가입을 한다")
+    void signup() {
+        PasswordEncoder encoder = new BCryptPasswordEncoder();
+        UserSignupRequest dto = new UserSignupRequest("yoonKun", "yoonms0617", "12345678");
+        String encoded = encoder.encode(dto.getPassword());
+        User user = new User(dto.getNickname(), dto.getUsername(), encoded);
+
+        given(userRepository.existsByNickname(any(String.class))).willReturn(false);
+        given(userRepository.existsByUsername(any(String.class))).willReturn(false);
+        given(passwordEncoder.encode(any(String.class))).willReturn(encoded);
+        given(userRepository.save(any(User.class))).willReturn(user);
+
+        userService.signup(dto);
+
+        then(userRepository).should(atLeastOnce()).existsByNickname(any(String.class));
+        then(userRepository).should(atLeastOnce()).existsByUsername(any(String.class));
+        then(passwordEncoder).should(atLeastOnce()).encode(any(String.class));
+        then(userRepository).should(atLeastOnce()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임으로 회원가입을 시도할 경우 예외가 발생한다")
+    void signup_duplicateNickname() {
+        UserSignupRequest dto = new UserSignupRequest("yoonKun", "yoonms0617", "12345678");
+
+        given(userRepository.existsByNickname(any(String.class))).willReturn(true);
+
+        assertThatThrownBy(() -> userService.signup(dto))
+                .isInstanceOf(DuplicateNicknameException.class);
+
+        then(userRepository).should(atLeastOnce()).existsByNickname(any(String.class));
+        then(userRepository).should(never()).existsByUsername(any(String.class));
+        then(passwordEncoder).should(never()).encode(any(String.class));
+        then(userRepository).should(never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 아이디로 회원가입을 시도할 경우 예외가 발생한다")
+    void signup_duplicateUsername() {
+        UserSignupRequest dto = new UserSignupRequest("yoonKun", "yoonms0617", "12345678");
+
+        given(userRepository.existsByNickname(any(String.class))).willReturn(false);
+        given(userRepository.existsByUsername(any(String.class))).willReturn(true);
+
+        assertThatThrownBy(() -> userService.signup(dto))
+                .isInstanceOf(DuplicateUsernameException.class);
+
+        then(userRepository).should(atLeastOnce()).existsByNickname(any(String.class));
+        then(userRepository).should(atLeastOnce()).existsByUsername(any(String.class));
+        then(passwordEncoder).should(never()).encode(any(String.class));
+        then(userRepository).should(never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("닉네임이 존재하는지 확인한다")
+    void checkNickname() {
+        given(userRepository.existsByNickname(any(String.class))).willReturn(false);
+
+        userService.checkNickname("yoonKun");
+
+        then(userRepository).should(atLeastOnce()).existsByNickname(any(String.class));
+    }
+
+    @Test
+    @DisplayName("닉네임이 존재하는 경우 예외가 발생한다")
+    void checkNickname_duplicate() {
+        given(userRepository.existsByNickname(any(String.class))).willReturn(true);
+
+        assertThatThrownBy(() -> userService.checkNickname("yoonKun"))
+                .isInstanceOf(DuplicateNicknameException.class);
+
+        then(userRepository).should(atLeastOnce()).existsByNickname(any(String.class));
+    }
+
+    @Test
+    @DisplayName("아이디가 존재하는지 확인한다")
+    void checkUsername() {
+        given(userRepository.existsByUsername(any(String.class))).willReturn(false);
+
+        userService.checkUsername("yoonms0617");
+
+        then(userRepository).should(atLeastOnce()).existsByUsername(any(String.class));
+    }
+
+    @Test
+    @DisplayName("아이디가 존재하는 경우 예외가 발생한다")
+    void checkUsername_duplicate() {
+        given(userRepository.existsByUsername(any(String.class))).willReturn(true);
+
+        assertThatThrownBy(() -> userService.checkUsername("yoonKun"))
+                .isInstanceOf(DuplicateUsernameException.class);
+
+        then(userRepository).should(atLeastOnce()).existsByUsername(any(String.class));
+    }
+
+}

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -1,0 +1,14 @@
+spring:
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:


### PR DESCRIPTION
## 작업 내용

회원가입 기능 구현

- 닉네임, 아이디, 비밀번호, 권한 필드를 가지는 User 엔티티 추가
- JPA Auditing 기능을 사용해 엔티티 생성시 생성 일자와 수정 일자를 자동으로 등록
- UserRepository, UserService, UserController 추가 및 각 레이어별 테스트 수행
- 회원가입시 비밀번호는 `BCryptpasswordencoder`를 사용해 암호화한 후 데이터베이스에 저장
- 닉네임/아이디 중복 예외 추가 예외 발생시 GlobalExceptionHandler에서 핸들링
- `@Valid`를 사용해 입력값 유효성 검증시 발생하는 `Methodargumentnotvalidexception`를 처리하는 핸들러 추가

#

#### 이슈 번호

close #3 